### PR TITLE
Wrap category editor JSX in fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,36 +207,38 @@
                       </button>
                     </div>
                     {showCategories && (
-                    <div className="flex flex-wrap gap-2 items-center mb-3">
-                    {categories.map((c) => (
-                      <div key={c.id} className="flex items-center gap-2 bg-neutral-100 rounded-xl px-2 py-1">
-                        <input
-                          className="w-36 px-2 py-1 text-sm border rounded-lg"
-                          value={c.name}
-                          onChange={(e)=>{
-                            const val = e.target.value; setCategories((arr)=>arr.map(x=>x.id===c.id?{...x,name:val}:x));
-                          }}
-                        />
-                        <input
-                          type="color"
-                          value={c.color}
-                          onChange={(e)=>{
-                            const val = e.target.value; setCategories((arr)=>arr.map(x=>x.id===c.id?{...x,color:val}:x));
-                          }}
-                        />
-                        <button
-                          className="p-1 rounded-lg hover:bg-red-50 text-red-600"
-                          title="Remove category"
-                          onClick={()=>removeCategory(c.id)}
-                          disabled={categories.length<=1}
-                        >
-                          <Trash2 className="w-4 h-4"/>
-                        </button>
+                    <>
+                      <div className="flex flex-wrap gap-2 items-center mb-3">
+                      {categories.map((c) => (
+                        <div key={c.id} className="flex items-center gap-2 bg-neutral-100 rounded-xl px-2 py-1">
+                          <input
+                            className="w-36 px-2 py-1 text-sm border rounded-lg"
+                            value={c.name}
+                            onChange={(e)=>{
+                              const val = e.target.value; setCategories((arr)=>arr.map(x=>x.id===c.id?{...x,name:val}:x));
+                            }}
+                          />
+                          <input
+                            type="color"
+                            value={c.color}
+                            onChange={(e)=>{
+                              const val = e.target.value; setCategories((arr)=>arr.map(x=>x.id===c.id?{...x,color:val}:x));
+                            }}
+                          />
+                          <button
+                            className="p-1 rounded-lg hover:bg-red-50 text-red-600"
+                            title="Remove category"
+                            onClick={()=>removeCategory(c.id)}
+                            disabled={categories.length<=1}
+                          >
+                            <Trash2 className="w-4 h-4"/>
+                          </button>
+                        </div>
+                      ))}
+                      <button onClick={addCategory} className="px-3 py-2 rounded-xl bg-white shadow hover:bg-neutral-100 flex items-center gap-2"><Plus className="w-4 h-4"/> Add category</button>
                       </div>
-                    ))}
-                    <button onClick={addCategory} className="px-3 py-2 rounded-xl bg-white shadow hover:bg-neutral-100 flex items-center gap-2"><Plus className="w-4 h-4"/> Add category</button>
-                    </div>
-                    <div className="text-xs text-neutral-600">Tip: edit names/colors. You can delete categories; items using it are reassigned to the first category.</div>
+                      <div className="text-xs text-neutral-600">Tip: edit names/colors. You can delete categories; items using it are reassigned to the first category.</div>
+                    </>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- wrap category management UI in a fragment to prevent adjacent JSX error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c8314b9b40832786459e3c446cfff0