### PR TITLE
Allow positioning milestones between periods

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,15 @@
           { id: crypto.randomUUID(), name: "Ingestão e QA AEP", category: "ingestao", start: 1, end: 3, type: "task" },
           { id: crypto.randomUUID(), name: "RTCDP > Salesforce", category: "integracao", start: 1, end: 3, type: "task" },
           { id: crypto.randomUUID(), name: "Ativação RTCDP > Salesforce", category: "ativacao", start: 3, end: 5, type: "task" },
-          { id: crypto.randomUUID(), name: "Passagem de Conhecimento", category: "handoff", start: 4, end: 4, type: "milestone" },
+          {
+            id: crypto.randomUUID(),
+            name: "Passagem de Conhecimento",
+            category: "handoff",
+            start: 4,
+            end: 4,
+            type: "milestone",
+            milestonePosition: 4.5,
+          },
         ];
       }
 
@@ -118,6 +126,14 @@
             if (maxIndex < 0) {
               let changed = false;
               const reset = rs.map((r) => {
+                if (r.type === "milestone") {
+                  const currentPosition = Number.isFinite(r.milestonePosition) ? r.milestonePosition : 0;
+                  if (r.start !== 0 || r.end !== 0 || currentPosition !== 0) {
+                    changed = true;
+                    return { ...r, start: 0, end: 0, milestonePosition: 0 };
+                  }
+                  return r;
+                }
                 if (r.start !== 0 || r.end !== 0) {
                   changed = true;
                   return { ...r, start: 0, end: 0 };
@@ -126,10 +142,25 @@
               });
               return changed ? reset : rs;
             }
+            const minMilestonePosition = 0.5;
+            const maxMilestonePosition = maxIndex + 0.5;
             let changed = false;
             const next = rs.map((r) => {
-              let start = Math.min(Math.max(0, r.start), maxIndex);
-              let end = Math.min(Math.max(0, r.end), maxIndex);
+              if (r.type === "milestone") {
+                const rawPosition = Number.isFinite(r.milestonePosition) ? r.milestonePosition : r.start + 0.5;
+                const clamped = Math.min(maxMilestonePosition, Math.max(minMilestonePosition, rawPosition));
+                const snapped = Math.round(clamped * 2) / 2;
+                const nextStart = Math.min(maxIndex, Math.max(0, Math.floor(snapped)));
+                if (r.start !== nextStart || r.end !== nextStart || r.milestonePosition !== snapped) {
+                  changed = true;
+                  return { ...r, start: nextStart, end: nextStart, milestonePosition: snapped };
+                }
+                return r;
+              }
+              const safeStart = Number.isFinite(r.start) ? r.start : 0;
+              const safeEnd = Number.isFinite(r.end) ? r.end : safeStart;
+              let start = Math.min(Math.max(0, Math.round(safeStart)), maxIndex);
+              let end = Math.min(Math.max(0, Math.round(safeEnd)), maxIndex);
               if (end < start) end = start;
               if (start !== r.start || end !== r.end) {
                 changed = true;
@@ -151,7 +182,15 @@
         }
         function addMilestoneAt(index = rows.length) {
           setRows((r) => {
-            const base = { id: crypto.randomUUID(), name: `Novo marco ${r.length + 1}`, category: categories[0].id, start: 0, end: 0, type: "milestone" };
+            const base = {
+              id: crypto.randomUUID(),
+              name: `Novo marco ${r.length + 1}`,
+              category: categories[0].id,
+              start: 0,
+              end: 0,
+              type: "milestone",
+              milestonePosition: 0.5,
+            };
             const copy = [...r];
             copy.splice(index, 0, base);
             return copy;
@@ -187,18 +226,31 @@
 
           const rowsSource = Array.isArray(j.rows) ? j.rows : defaults.rows;
           const normalizedRows = rowsSource.map((r, idx) => {
-            const start = Number.isFinite(r.start) ? r.start : 0;
+            let start = Number.isFinite(r.start) ? r.start : 0;
             let end = Number.isFinite(r.end) ? r.end : start;
-            if (end < start) end = start;
             const category = categoryIds.has(r.category) ? r.category : fallbackCategoryId;
-            return {
+            const type = r.type === "milestone" ? "milestone" : "task";
+            if (type !== "milestone" && end < start) end = start;
+            if (type === "milestone") end = start;
+            start = Math.floor(start);
+            end = Math.floor(end);
+            const baseRow = {
               id: r.id ?? crypto.randomUUID(),
               name: r.name ?? `Activity ${idx + 1}`,
               category,
               start,
               end,
-              type: r.type === "milestone" ? "milestone" : "task",
+              type,
             };
+            if (type === "milestone") {
+              const rawPosition = Number.isFinite(r.milestonePosition)
+                ? r.milestonePosition
+                : Number.isFinite(r.position)
+                ? r.position
+                : start + 0.5;
+              return { ...baseRow, milestonePosition: rawPosition };
+            }
+            return baseRow;
           });
 
           setTimelineMode(j.timelineMode ?? defaults.timelineMode);
@@ -653,25 +705,44 @@
 
         useEffect(()=>{
           function onMove(e){
-            if(!drag || !containerRef.current) return;
+            if(!drag || !containerRef.current || cols <= 0) return;
             const rect = containerRef.current.getBoundingClientRect();
             const usable = rect.width - 0;
             const x = Math.max(0, Math.min(e.clientX - rect.left, usable));
             const per = usable / cols;
-            const deltaCols = Math.round((x - drag.startX) / per);
             setRows((rs)=>rs.map((r)=>{
               if(r.id !== drag.rowId) return r;
               if(drag.type === "move"){
+                if(r.type === "milestone"){
+                  const startPosition = Number.isFinite(drag.startMilestonePosition)
+                    ? drag.startMilestonePosition
+                    : Number.isFinite(r.milestonePosition)
+                    ? r.milestonePosition
+                    : r.start + 0.5;
+                  const minPosition = 0.5;
+                  const maxPosition = Math.max(minPosition, cols - 0.5);
+                  let nextPosition = startPosition + (x - drag.startX) / per;
+                  nextPosition = Math.min(maxPosition, Math.max(minPosition, nextPosition));
+                  const snapped = Math.round(nextPosition * 2) / 2;
+                  const nextStart = Math.min(cols - 1, Math.max(0, Math.floor(snapped)));
+                  if(r.start === nextStart && r.end === nextStart && r.milestonePosition === snapped){
+                    return r;
+                  }
+                  return { ...r, start: nextStart, end: nextStart, milestonePosition: snapped };
+                }
+                const deltaCols = Math.round((x - drag.startX) / per);
                 let ns = Math.max(0, Math.min(drag.startStart + deltaCols, cols-1));
                 let ne = ns + (drag.startEnd - drag.startStart);
                 if(ne > cols-1){ ne = cols-1; ns = ne - (drag.startEnd - drag.startStart); }
                 return { ...r, start: ns, end: ne };
               }
               if(drag.type === "left"){
+                const deltaCols = Math.round((x - drag.startX) / per);
                 let ns = Math.max(0, Math.min(drag.startStart + deltaCols, r.end));
                 return { ...r, start: Math.min(ns, r.end) };
               }
               if(drag.type === "right"){
+                const deltaCols = Math.round((x - drag.startX) / per);
                 let ne = Math.max(r.start, Math.min(drag.startEnd + deltaCols, cols-1));
                 return { ...r, end: Math.max(ne, r.start) };
               }
@@ -698,8 +769,37 @@
             <div className="mt-2 grid" style={{ gridTemplateColumns: gridTemplate }}>
               {rows.map((r, idx) => {
                 const cat = categories.find((c)=>c.id===r.category) || categories[0];
-                const startLabel = labels[r.start]?.label;
-                const endLabel = labels[r.end]?.label;
+                const safeStartIndex = cols > 0 ? Math.min(cols - 1, Math.max(0, Math.round(Number.isFinite(r.start) ? r.start : 0))) : 0;
+                const safeEndIndex = cols > 0 ? Math.min(cols - 1, Math.max(0, Math.round(Number.isFinite(r.end) ? r.end : safeStartIndex))) : safeStartIndex;
+                const startLabel = labels[safeStartIndex]?.label;
+                const endLabel = labels[safeEndIndex]?.label;
+                const milestonePositionRaw = r.type === "milestone"
+                  ? Number.isFinite(r.milestonePosition)
+                    ? r.milestonePosition
+                    : (Number.isFinite(r.start) ? r.start : 0) + 0.5
+                  : null;
+                const milestonePosition = r.type === "milestone" && cols > 0
+                  ? Math.min(cols - 0.5, Math.max(0.5, Math.round(milestonePositionRaw * 2) / 2))
+                  : milestonePositionRaw;
+                let milestoneLabel = "";
+                if (r.type === "milestone" && cols > 0 && milestonePosition !== null) {
+                  const isBetween = Math.abs(milestonePosition - Math.round(milestonePosition)) < 1e-6;
+                  if (isBetween) {
+                    const rightIndex = Math.min(cols - 1, Math.max(0, Math.round(milestonePosition)));
+                    const leftIndex = Math.max(0, Math.min(cols - 1, rightIndex - 1));
+                    const leftLabel = labels[leftIndex]?.label;
+                    const rightLabel = labels[rightIndex]?.label;
+                    if (leftLabel && rightLabel && leftLabel !== rightLabel) {
+                      milestoneLabel = `${leftLabel} → ${rightLabel}`;
+                    } else {
+                      milestoneLabel = leftLabel || rightLabel || "";
+                    }
+                  } else {
+                    const centerIndex = Math.min(cols - 1, Math.max(0, Math.floor(milestonePosition)));
+                    milestoneLabel = labels[centerIndex]?.label || "";
+                  }
+                }
+                const milestoneTitle = milestoneLabel ? `${r.name} • ${milestoneLabel}` : r.name;
                 return (
                   <React.Fragment key={r.id}>
                     <div
@@ -731,7 +831,14 @@
                           className="absolute group cursor-grab active:cursor-grabbing"
                           onMouseDown={(e)=>{
                             const rect = e.currentTarget.parentElement.getBoundingClientRect();
-                            setDrag({ rowId:r.id, type:"move", startX: e.clientX - rect.left, startStart: r.start, startEnd: r.end });
+                            setDrag({
+                              rowId:r.id,
+                              type:"move",
+                              startX: e.clientX - rect.left,
+                              startStart: r.start,
+                              startEnd: r.end,
+                              startMilestonePosition: (milestonePosition ?? ((Number.isFinite(r.start) ? r.start : 0) + 0.5)),
+                            });
                           }}
                           onDoubleClick={()=>{ if(confirm('Delete this activity?')) onRemoveRow(r.id); }}
                           onContextMenu={(e)=>{
@@ -739,7 +846,7 @@
                             setMenu({ open:true, x:e.clientX, y:e.clientY, rowId:r.id });
                           }}
                           style={{
-                            left: `calc((100% / ${cols}) * ${r.start + 0.5})`,
+                            left: `calc((100% / ${cols}) * ${milestonePosition ?? ((Number.isFinite(r.start) ? r.start : 0) + 0.5)})`,
                             top: -rowHeight + rowHeight * 0.15,
                             width: rowHeight * 0.7,
                             height: rowHeight * 0.7,
@@ -747,7 +854,7 @@
                             transform: "translate(-50%, 0) rotate(45deg)",
                             boxShadow: "0 4px 10px rgba(0,0,0,0.15)",
                           }}
-                          title={startLabel ? `${r.name} • ${startLabel}` : r.name}
+                          title={milestoneTitle}
                         />
                       ) : (
                         <div


### PR DESCRIPTION
## Summary
- store a milestonePosition for milestone rows when creating or importing timelines so their placement can sit between periods
- clamp milestone positions as period labels change and keep compatibility with existing data
- update the preview drag/tooltip logic to snap milestones to half columns and render correct labels when placed between periods

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd45241eb083279d8ba1d2a6799600